### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/MIME/Base64/Perl.pm6
+++ b/lib/MIME/Base64/Perl.pm6
@@ -1,5 +1,5 @@
 use v6;
-class MIME::Base64::Perl;
+unit class MIME::Base64::Perl;
 
 # 6 bit encoding - 64 characters needed
 # note: range operator removed due to current jvm failures


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.