### PR TITLE
Fix tests on big endian

### DIFF
--- a/t/binary-and-long-line.rakutest
+++ b/t/binary-and-long-line.rakutest
@@ -34,7 +34,7 @@ my blob8 $fancy-utf16-chars-bytes =
     pack 'S' x $fancy-utf16-chars.elems, $fancy-utf16-chars.list;
 is $mime.encode($fancy-utf16-chars-bytes), 'DDADJnQiowM=',
     'encode some binary utf16 data';
-is $mime.decode('DDADJnQiowM=').decode('UTF-16'), $fancy-unicode-chars,
+is $mime.decode('DDADJnQiowM=').decode('UTF-16LE'), $fancy-unicode-chars,
     'decode some binary utf16 data';
 
 $fancy-unicode-chars x= 7;
@@ -44,7 +44,7 @@ $fancy-utf16-chars-bytes =
     pack 'S' x $fancy-utf16-chars.elems, $fancy-utf16-chars.list;
 is $mime.encode($fancy-utf16-chars-bytes), $long-enc,
     'encode enough binary utf16 data for more than one line of result';
-is $mime.decode($long-enc).decode('UTF-16'), $fancy-unicode-chars,
+is $mime.decode($long-enc).decode('UTF-16LE'), $fancy-unicode-chars,
     'decode more than one line encoding of binary utf16 data';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
The base64 encoded UTF-16 is little endian but without BOM. So when decoding the endianess can vary. Specifying UTF-16LE explicitly ensures it always chooses the correct one.